### PR TITLE
Use new option `--delete-emptydir-data` for drain

### DIFF
--- a/src/node-menu.tsx
+++ b/src/node-menu.tsx
@@ -57,7 +57,7 @@ export function NodeMenu(props: Renderer.Component.KubeObjectMenuProps<Node>) {
   };
 
   const drain = () => {
-    const command = `${kubectlPath} drain ${nodeName} --delete-local-data --ignore-daemonsets --force`;
+    const command = `${kubectlPath} drain ${nodeName} --delete-emptydir-data --ignore-daemonsets --force`;
 
     ConfirmDialog.open({
       ok: () => sendToTerminal(command),


### PR DESCRIPTION
Describe the bug

Draining node using tree-dots-menu in Nodes view results with error:

kubectl drain ip-10-1-2-3.eu-central-1.compute.internal --delete-local-data --ignore-daemonsets --force
error: unknown flag: --delete-local-data

when used with kubectl 1.31 which is autoinstalled when used with Kubernetes 1.31 cluster.

Expected behavior
Flag --delete-local-data has been deprecated, This option is deprecated and will be deleted. Use --delete-emptydir-data.

Environment (please complete the following information):

    Freelens Version: 0.1.0
    OS: MacOS
    Installation method (e.g. snap or AppImage in Linux): npm run build

Additional context
The default kubectl version is now 1.23.3 and it had --delete-local-data already deprecated. It looks like this option is removed from 1.31.0

Fixes https://github.com/freelensapp/freelens/issues/31