### PR TITLE
Use xvfb for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -103,10 +103,17 @@ jobs:
       - name: Build Electron app
         run: cd ../freelens && npm run build:app -- -- -- dir --${{ matrix.arch }}
 
-      - name: Run integration tests
+      - name: Run integration tests (Linux)
+        if: runner.os == 'Linux'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3
           retry_on: timeout
-          command: cd ../freelens && npm run test:integration
+          command: |
+            cd ../freelens
+            sudo chown root:root freelens/dist/linux-unpacked/chrome-sandbox
+            sudo chmod 4755 freelens/dist/linux-unpacked/chrome-sandbox
+            xvfb-run -a npm run test:integration
+        env:
+          DEBUG: pw:browser


### PR DESCRIPTION
Tests should use display before we want to reenable them.